### PR TITLE
Made opening the coinpayments link in the browser & double triggering of the wallet download event is prevented

### DIFF
--- a/App.js
+++ b/App.js
@@ -20,24 +20,27 @@ import bgImg from './android/app/src/main/res/assets/img/login.jpg';
 import SplashScreen from 'react-native-splash-screen';
 
 const INJECTED = `
-  window.addEventListener('download_wallet', function (event) {
-    const message = 'download_wallet' + event.detail;
-    window.ReactNativeWebView.postMessage(message);
-  });
-  (function () {
-    function wrap(fn) {
-      return function wrapper() {
-        const res = fn.apply(this, arguments);
-        window.ReactNativeWebView.postMessage('navigationStateChange');
-        return res;
-      }
-    }
-    history.pushState = wrap(history.pushState);
-    history.replaceState = wrap(history.replaceState);
-    window.addEventListener('popstate', function () {
-      window.ReactNativeWebView.postMessage('navigationStateChange');
+  if (!window.ReactNativeWebView.hasInjectedJS) {
+    window.addEventListener('download_wallet', function (event) {
+      const message = 'download_wallet' + event.detail;
+      window.ReactNativeWebView.postMessage(message);
     });
-  })();
+    (function () {
+      function wrap(fn) {
+        return function wrapper() {
+          const res = fn.apply(this, arguments);
+          window.ReactNativeWebView.postMessage('navigationStateChange');
+          return res;
+        }
+      }
+      history.pushState = wrap(history.pushState);
+      history.replaceState = wrap(history.replaceState);
+      window.addEventListener('popstate', function () {
+        window.ReactNativeWebView.postMessage('navigationStateChange');
+      });
+    })();
+    window.ReactNativeWebView.hasInjectedJS = true;
+  }
   true;
 `;
 
@@ -128,6 +131,7 @@ class App extends Component {
     if (
       externalLinks.includes(event.title) ||
       event.title.startsWith('https://t.me/') ||
+      event.title.startsWith('https://www.coinpayments.net/index.php') ||
       (event.title === 'https://www.onyxpay.co' && event.canGoBack === true)
     ) {
       this.webview.goBack();

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -137,7 +137,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 3
-        versionName "1.0.0"
+        versionName "1.0.1"
     }
     splits {
         abi {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -136,7 +136,7 @@ android {
         applicationId "com.onyxpay"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
+        versionCode 3
         versionName "1.0.0"
     }
     splits {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -19,3 +19,4 @@
 
 android.useAndroidX=true
 android.enableJetifier=true
+org.gradle.java.home=C:\\Program Files\\Java\\jdk1.8.0_221

--- a/constants.js
+++ b/constants.js
@@ -5,7 +5,6 @@ export const uri = 'https://preprod.onyxpay.co';
 export const walletPath = '/storage/emulated/0/Onyxpay';
 
 export const externalLinks = [
-  'https://www.coinpayments.net/index.php',
   'https://wallet.onyxpay.co',
   'https://onyxcoin.io',
 ];


### PR DESCRIPTION
[ONXP-1679 Coinpayments home page is opened in browser instead of payment info page](https://scaddr.apriorit.com/jira/browse/ONXP-1679)
[ONXP-1680 Several copies of wallet file are saved when export from Wallet settings](https://scaddr.apriorit.com/jira/browse/ONXP-1680)